### PR TITLE
fix(type): fix page size type for `search` api

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -464,7 +464,7 @@ export interface SonarQubeWebApi {
        * @default 1
        * @example 42
        */
-      readonly p?: boolean | 'yes' | 'no';
+      readonly p?: number;
 
       /**
        * Comma-separated list of project keys. Maximum allowed values are 1000.


### PR DESCRIPTION
## Description

Fix the wrong type of page size. It should be `number`.