### PR TITLE
ci: upload coverage to GitHub code coverage API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,10 +35,11 @@ jobs:
       - name: 'Test'
         run: npm run test
 
-      - name: 'Upload coverage'
+      - name: 'Upload coverage report'
         uses: actions/upload-artifact@v7.0.1
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         with:
-          name: 'coverage'
+          name: 'cobertura-report'
           path: 'coverage/cobertura-coverage.xml'
           if-no-files-found: 'error'
 
@@ -53,3 +54,26 @@ jobs:
 
       - name: 'Build'
         run: npm run build
+
+  upload-coverage:
+    name: 'Upload coverage'
+    needs: ['ci']
+    if: ${{ !cancelled() && needs.ci.result == 'success' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
+    runs-on: ['ubuntu-latest']
+    timeout-minutes: 10
+    permissions:
+      contents: 'read'
+      code-quality: 'write' # to upload coverage to GitHub's code coverage API
+      pull-requests: 'read' # to resolve the PR number on push events
+    steps:
+      - name: 'Download coverage report'
+        uses: actions/download-artifact@v8.0.1
+        with:
+          name: 'cobertura-report'
+
+      - name: 'Upload to code coverage API'
+        uses: actions/upload-code-coverage@v1.3.0
+        with:
+          file: 'cobertura-coverage.xml'
+          language: 'TypeScript'
+          label: 'code-coverage/jest'


### PR DESCRIPTION
Restructures coverage reporting in CI into a dedicated `upload-coverage` job, following the [`actions/upload-code-coverage` separate-job example](https://github.com/actions/upload-code-coverage).

## What changed
- The `ci` job now uploads the Cobertura report (`coverage/cobertura-coverage.xml`) as an artifact and keeps `contents: read` only.
- A new `upload-coverage` job `needs: ci`, downloads that artifact, and publishes it to GitHub's native code coverage API via `actions/upload-code-coverage@v1.3.0`.

## Why a separate job
- Isolates the `code-quality: write` permission to the upload step instead of the whole build.
- Mirrors the upstream recommended pattern.

## Notes
- Fork PRs are skipped (the action can't upload for forks); guarded via `if` on both the artifact upload and the upload job.
- `pull-requests: read` lets the action resolve the PR number on `push` events.
- Actions pinned to full `x.x.x` tags: `upload-artifact@v7.0.1`, `download-artifact@v8.0.1`, `upload-code-coverage@v1.3.0`.