### PR TITLE
ci: retry npm audit signatures on transient failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,20 @@ jobs:
           if-no-files-found: 'error'
 
       - name: 'Audit'
-        run: npm audit signatures
+        # Registry attestation lookups occasionally 404 transiently, so retry
+        # with backoff before treating it as a real signature failure.
+        run: |
+          for attempt in 1 2 3; do
+            if npm audit signatures; then
+              exit 0
+            fi
+            if [ "$attempt" -lt 3 ]; then
+              echo "::warning::npm audit signatures failed (attempt ${attempt}/3), retrying in $((attempt * 10))s..."
+              sleep $((attempt * 10))
+            fi
+          done
+          echo "::error::npm audit signatures failed after 3 attempts"
+          exit 1
 
       - name: 'Lint'
         run: npm run lint:check


### PR DESCRIPTION
## What

Wrap the `Audit` step (`npm audit signatures`) in a retry-with-backoff loop (up to 3 attempts, 10s/20s linear backoff).

## Why

The merge of #15 surfaced a flaky failure on `main`:

```
npm error code E404
npm error 404 Not Found - GET https://registry.npmjs.org/-/npm/v1/attestations/universal-user-agent@7.0.3 - Not found
```

`npm audit signatures` verifies registry signatures/attestations for **every** installed package. The registry's attestation endpoint intermittently returns a transient 404, which fails the whole step — and on `push` that also blocks the `release` job. Locally the same command passes (`1016 packages have verified registry signatures, 108 verified attestations`), confirming the failure is transient, not a real signature problem.

## Behavior

- Passes immediately when the audit succeeds (no added latency on the happy path).
- Retries on failure with a short backoff so a registry hiccup self-heals.
- Still fails the build if all 3 attempts fail (a genuine signature problem is not masked).