### PR TITLE
feat: support system api group (ping, status, health)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This package provides an easy-to-use interface for requesting various SonarQube 
   - ALM Settings
   - Project Branches
   - Project Badges
+  - System
   - More…
 
 ## Installation
@@ -73,7 +74,7 @@ const sonar = createClient({
 | --------- | :------: | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `baseURL` |    ✓     | The base URL for the SonarQube instance. This should be the root URL without any trailing slashes. Example: `'https://sonarqube.example.com'`                                                  |
 | `token`   |    ✓     | The authentication token for your SonarQube instance.                                                                                                                                          |
-| `wrap`    |    ✖     | A function that wraps around the API requests. Can be used to limit the API requests or add custom logic around it. If not provided, the default behavior is simply to invoke the API request. |
+| `wrap`    |    ✖    | A function that wraps around the API requests. Can be used to limit the API requests or add custom logic around it. If not provided, the default behavior is simply to invoke the API request. |
 
 ### API Methods
 

--- a/src/lib/sonar-client.spec.ts
+++ b/src/lib/sonar-client.spec.ts
@@ -62,6 +62,41 @@ describe('createClient()', () => {
     expect(result).toBe(mockResponseText);
   });
 
+  it('should fetch the system health as JSON', async () => {
+    const mockResponse = { health: 'GREEN', causes: [] };
+    mockFetch.mockResolvedValueOnce({ ok: true, json: jest.fn().mockResolvedValueOnce(mockResponse) });
+
+    const client = createClient(defaultOptions);
+    const result = await client.api.system.health();
+
+    expect(mockFetch).toHaveBeenCalledWith(`${baseURL}/api/system/health?`, expect.any(Object));
+    expect(result).toEqual(mockResponse);
+  });
+
+  it('should ping the server returning plain text', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: true, text: jest.fn().mockResolvedValueOnce('pong') });
+
+    const client = createClient(defaultOptions);
+    const result = await client.api.system.ping();
+
+    expect(mockFetch).toHaveBeenCalledWith(`${baseURL}/api/system/ping?`, {
+      method: 'GET',
+      headers: { Authorization: `Basic ${Buffer.from(`${token}:`).toString('base64')}` },
+    });
+    expect(result).toBe('pong');
+  });
+
+  it('should fetch the system status as JSON', async () => {
+    const mockResponse = { id: 'AU-Tpxb--iU5OvuD2FLy', version: '6.3.0.1234', status: 'UP' };
+    mockFetch.mockResolvedValueOnce({ ok: true, json: jest.fn().mockResolvedValueOnce(mockResponse) });
+
+    const client = createClient(defaultOptions);
+    const result = await client.api.system.status();
+
+    expect(mockFetch).toHaveBeenCalledWith(`${baseURL}/api/system/status?`, expect.any(Object));
+    expect(result).toEqual(mockResponse);
+  });
+
   it('should remove trailing slashes from baseURL', () => {
     mockFetch.mockResolvedValueOnce({ ok: true });
 

--- a/src/lib/sonar-client.ts
+++ b/src/lib/sonar-client.ts
@@ -74,5 +74,10 @@ class SonarQubeClient implements SonarClient {
     server: {
       version: () => this.request('GET', 'server/version', {}, 'text'),
     },
+    system: {
+      health: () => this.request('GET', 'system/health', {}, 'json'),
+      ping: () => this.request('GET', 'system/ping', {}, 'text'),
+      status: () => this.request('GET', 'system/status', {}, 'json'),
+    },
   };
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -676,6 +676,84 @@ export interface SonarQubeWebApi {
      */
     version(): Promise<string>;
   };
+
+  /** @see https://next.sonarqube.com/sonarqube/web_api/api/system */
+  readonly system: {
+    /**
+     * Provide health status of SonarQube.
+     *
+     * - `GREEN`: SonarQube is fully operational
+     * - `YELLOW`: SonarQube is usable, but it needs attention in order to be fully operational
+     * - `RED`: SonarQube is not operational
+     *
+     * Requires the 'Administer System' permission or system passcode (see sonar.web.systemPasscode in sonar.properties).
+     * When SonarQube is in safe mode (waiting or running a database upgrade), only the authentication with a system passcode is supported.
+     * @since 6.6
+     * @see https://next.sonarqube.com/sonarqube/web_api/api/system?query=health
+     */
+    health(): Promise<{
+      /** Health status of the SonarQube instance. */
+      readonly health: 'GREEN' | 'YELLOW' | 'RED';
+
+      /** Reasons explaining a non-`GREEN` health status. */
+      readonly causes: readonly { readonly message: string }[];
+
+      /** Health information per node, present only on a cluster deployment. */
+      readonly nodes?: readonly {
+        readonly name: string;
+        readonly type: 'APPLICATION' | 'SEARCH';
+        readonly host: string;
+        readonly port: number;
+        readonly startedAt: string;
+        readonly health: 'GREEN' | 'YELLOW' | 'RED';
+        readonly causes: readonly { readonly message: string }[];
+      }[];
+    }>;
+
+    /**
+     * Answers "pong" as plain text.
+     *
+     * Requires no permission and works without authentication.
+     * @since 6.3
+     * @see https://next.sonarqube.com/sonarqube/web_api/api/system?query=ping
+     * @example 'pong'
+     */
+    ping(): Promise<string>;
+
+    /**
+     * Get state information about SonarQube.
+     *
+     * - `status`: the running status
+     *   - `STARTING`: SonarQube Web Server is up and serving some Web Services
+     *     (e.g. `api/system/status`) but initialization is still ongoing.
+     *   - `UP`: SonarQube instance is up and running.
+     *   - `DOWN`: SonarQube instance is up but not running because migration has
+     *     failed (refer to WS `/api/system/migrate_db` for details) or some other
+     *     reason (check logs).
+     *   - `RESTARTING`: SonarQube instance is still up but a restart has been
+     *     requested (refer to WS `/api/system/restart` for details).
+     *   - `DB_MIGRATION_NEEDED`: database migration is required.
+     *   - `DB_MIGRATION_RUNNING`: DB migration is running (refer to WS
+     *     `/api/system/migrate_db` for details).
+     *
+     * Requires no permission and works without authentication.
+     * @since 5.2
+     * @see https://next.sonarqube.com/sonarqube/web_api/api/system?query=status
+     */
+    status(): Promise<{
+      /** Unique identifier of the SonarQube instance. */
+      readonly id: string;
+
+      /**
+       * Version of SonarQube.
+       * @example '6.3.0.1234'
+       */
+      readonly version: string;
+
+      /** Running status of the SonarQube instance. */
+      readonly status: 'STARTING' | 'UP' | 'DOWN' | 'RESTARTING' | 'DB_MIGRATION_NEEDED' | 'DB_MIGRATION_RUNNING';
+    }>;
+  };
 }
 
 export type WrapRequestFunction = <ReturnType>(func: () => PromiseLike<ReturnType> | ReturnType) => PromiseLike<ReturnType>;

--- a/test/e2e.mjs
+++ b/test/e2e.mjs
@@ -5,13 +5,17 @@ const baseURL = process.env.SONAR_BASE_URL ?? 'http://localhost:9000';
 
 console.log(`Running e2e against ${baseURL}`);
 
-const client = createClient({ baseURL });
+const sonar = createClient({ baseURL });
 
-const ping = await client.request('GET', 'system/ping', {}, 'text');
+const ping = await sonar.request('GET', 'system/ping', {}, 'text');
 assert.equal(ping.trim(), 'pong', `expected system/ping to return 'pong', got '${ping}'`);
-console.log('system/ping → pong');
+console.log('system/ping (request) → pong');
 
-const status = await client.request('GET', 'system/status', {}, 'json');
+const structuredPing = await sonar.api.system.ping();
+assert.equal(structuredPing.trim(), 'pong', `expected api.system.ping() to return 'pong', got '${structuredPing}'`);
+console.log('system/ping (api) → pong');
+
+const status = await sonar.request('GET', 'system/status', {}, 'json');
 assert.equal(status.status, 'UP', `expected system status 'UP', got '${status.status}'`);
 assert.ok(typeof status.version === 'string' && status.version.length > 0, 'expected a non-empty version string');
 console.log(`system/status → ${status.status} (SonarQube ${status.version})`);


### PR DESCRIPTION
## Summary

Adds the SonarQube `system` API group to the typed client.

| Method | Endpoint | Auth | Returns |
| --- | --- | --- | --- |
| `api.system.ping()` | `GET system/ping` | anonymous | `'pong'` (text) |
| `api.system.status()` | `GET system/status` | anonymous | `{ id, version, status }` |
| `api.system.health()` | `GET system/health` | admin / passcode | `{ health, causes, nodes? }` |

`status` and `health` are fully-typed unions (`UP`/`DOWN`/…, `GREEN`/`YELLOW`/`RED`), with JSDoc, `@since`, permissions and `@see` links matching the existing style in `types.ts`.

## Changes
- `src/lib/types.ts` — `system` group added to `SonarQubeWebApi`.
- `src/lib/sonar-client.ts` — implementations (ping→text, status/health→json).
- `src/lib/sonar-client.spec.ts` — unit tests for all three (URL/method/parsed result).
- `test/e2e.mjs` — pings the live server **both ways**: raw `request('GET','system/ping',…)` and structured `api.system.ping()`.
- `README.md` — added "System" to the feature list.

## Verification
- `npm test` → 13 passed
- `npm run build` → ok (`system` types emitted to `dist/lib/types.d.ts`)
- `eslint` / `prettier` clean (pre-existing unrelated README prettier warning left untouched)
- e2e exercised against the dockerised SonarQube via the `e2e` CI job