### PR TITLE
docs: document npm OIDC trusted publishing in release flow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,7 +198,7 @@ jobs:
       contents: 'write' # to be able to publish a GitHub release
       issues: 'write' # to be able to comment on released issues
       pull-requests: 'write' # to be able to comment on released pull requests
-      id-token: 'write' # to enable use of OIDC for npm provenance
+      id-token: 'write' # OIDC: npm trusted publishing (token-free auth) + provenance
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v6.0.2

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,7 +97,8 @@ typing silently.
 - For non-dev-dependency changes, use the `fix` type/prefix.
 - Husky runs `commit-msg` (commitlint) and `pre-commit` (lint-staged) hooks.
 - Versioning/publishing is automated by **semantic-release** from commit messages —
-  do **not** bump `version` in `package.json` manually.
+  do **not** bump `version` in `package.json` manually. Publishing uses npm **OIDC
+  trusted publishing** (no `NPM_TOKEN`) with signed provenance.
 - Work on a topic branch and open a focused PR; keep changes small and reviewable.
 
 ## CI expectations
@@ -110,7 +111,8 @@ typing silently.
   `test/smoke.{mjs,cjs}`.
 - `e2e`: boots SonarQube via `docker-compose.yml` and runs `test/e2e.mjs` against
   the packed tarball.
-- `release`: runs only on push to `main`, gated on `ci`, `smoke`, and `e2e`.
+- `release`: runs only on push to `main`, gated on `ci`, `smoke`, and `e2e`. Publishes
+  to npm via OIDC trusted publishing (token-free) with provenance.
 
 A change is not "done" until CI would pass. Validate locally with the commands in
 the Setup section before pushing.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,6 +72,14 @@ cd "$OLDPWD" && docker compose down --volumes
 
 The `e2e` job in the CI workflow runs this automatically (against the uploaded package tarball) on every pull request and on pushes to `main`.
 
+### Releases
+
+Releases are fully automated by [semantic-release](https://semantic-release.gitbook.io/) — **do not** bump the `version` in `package.json` manually.
+
+- On every push to `main`, the `release` job (gated on `ci`, `smoke`, and `e2e`) analyzes the [Conventional Commits](https://www.conventionalcommits.org/) since the last release to decide the next version (`fix:` → patch, `feat:` → minor, `feat!:`/`BREAKING CHANGE` → major).
+- It then publishes the package (from `dist/`) to npm and creates the matching GitHub release.
+- Publishing uses **npm [trusted publishing](https://docs.npmjs.com/trusted-publishers) via GitHub Actions OIDC** — there is no `NPM_TOKEN`. The workflow's `id-token: write` permission lets npm exchange a short-lived OIDC token, and each release is published with signed [provenance](https://docs.npmjs.com/generating-provenance-statements). The trusted publisher is configured on the npm package settings (repo + `ci.yml` workflow).
+
 ## Need Help?
 
 If you encounter any issues or need clarification, feel free to open an issue or reach out to the maintainers.


### PR DESCRIPTION
## Why

After PR #22, releases publish to npm via **OIDC trusted publishing** (no `NPM_TOKEN`). That wasn't reflected in any docs, and the `ci.yml` `id-token` comment only mentioned provenance.

## Changes
- **CONTRIBUTING.md** — new "Releases" subsection under SDLC: semantic-release automation, conventional-commit → version mapping, publish-from-`dist/`, and **OIDC trusted publishing (token-free) + provenance** with a note that the trusted publisher is configured on the npm package settings.
- **AGENTS.md** — note that publishing uses OIDC trusted publishing (no `NPM_TOKEN`) with provenance, in both the commit/publish guidance and the `release` CI bullet.
- **ci.yml** — clarified the `id-token: write` comment: it covers trusted-publishing auth **and** provenance (was "provenance" only).

Docs/comment-only; no behavior change.

## Verification
- `prettier --check` clean (CONTRIBUTING.md, AGENTS.md)
- `ci.yml` still valid YAML