### PR TITLE
ci: set minimum GITHUB_TOKEN permissions for all jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
   ci:
     runs-on: 'ubuntu-latest'
     timeout-minutes: 10
+    permissions:
+      contents: 'read' # to check out the repository
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v6.0.2
@@ -96,6 +98,8 @@ jobs:
     needs: 'ci'
     runs-on: 'ubuntu-latest'
     timeout-minutes: 10
+    permissions:
+      contents: 'read' # to check out the repository
     strategy:
       fail-fast: false
       matrix:
@@ -130,6 +134,8 @@ jobs:
     needs: 'ci'
     runs-on: 'ubuntu-latest'
     timeout-minutes: 15
+    permissions:
+      contents: 'read' # to check out the repository
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v6.0.2


### PR DESCRIPTION
## Why

Resolves the 3 open **code scanning** alerts (`actions/missing-workflow-permissions`, medium) on `.github/workflows/ci.yml` — the `ci`, `smoke`, and `e2e` jobs did not restrict the `GITHUB_TOKEN`.

> Actions job or workflow does not limit the permissions of the GITHUB_TOKEN.

## Change

Add an explicit minimal `permissions` block to the three jobs that lacked one:

| Job | Permissions | Rationale |
| --- | --- | --- |
| `ci` | `contents: read` | checkout; `upload-artifact` needs no token scope |
| `smoke` | `contents: read` | checkout + `download-artifact` |
| `e2e` | `contents: read` | checkout + `download-artifact` + docker |

The other two jobs already declared least-privilege blocks and are unchanged:
- `upload-coverage`: `contents: read`, `code-quality: write`, `pull-requests: read`
- `release`: `contents: write`, `issues: write`, `pull-requests: write`, `id-token: write`

Every job now explicitly grants only what it needs.

## Verification
- `ci.yml` is valid YAML
- No functional change to any step